### PR TITLE
Handle multiple RESTRICT_ORIGIN domains & Security fix

### DIFF
--- a/back/taiga_contrib_google_auth/connector.py
+++ b/back/taiga_contrib_google_auth/connector.py
@@ -180,6 +180,6 @@ def me(access_code:str) -> tuple:
 
     profile = jwt.decode(idt, verify=False)
 
-    return User(id=profile['email'].split("@")[0],username=profile['email'].split("@")[0],full_name= "",email=profile['email'],bio= "")
+    return User(id=profile['email'],username=profile['email'].split("@")[0],full_name= "",email=profile['email'],bio= "")
 
 

--- a/back/taiga_contrib_google_auth/services.py
+++ b/back/taiga_contrib_google_auth/services.py
@@ -80,12 +80,12 @@ def google_register(username:str, email:str, full_name:str, google_id:int, bio:s
     return user
 
 
-def google_login_func(request, restrict_login:str=RESTRICT_LOGIN):
+def google_login_func(request, restrict_login:list=RESTRICT_LOGIN):
     code = request.DATA.get('code', None)
     token = request.DATA.get('token', None)
 
     user_info = connector.me(code)
-    if RESTRICT_LOGIN != None and user_info.email.split("@")[1] != restrict_login[0]:
+    if restrict_login and user_info.email.split("@")[1] not in restrict_login:
         raise GoogleApiError({"error_message": ("Login with this Google account is disabled.")})
 
     user = google_register(username=user_info.username,


### PR DESCRIPTION
This PR handle the multiple google account origins, `[ "company.tld", "ext.company.tld" ]` for example.

Also, it fixes a security issue where if you have the same first part of email address with two different domain you are the same person/user (ex: `plop@company.tld` and `plop@ext.company.tld` are the same `plop` user).

> Be aware that this change breaks existing users and you'll have to edit them in the database to recover them !
> Since all my users where from the same entity when I did that change I just had to run that query : `UPDATE FROM users_authusersdata SET value = value || '@domain.tld';` on postgres

PS: I might have mispelled the table and it changes all users so be sure to check and understand what you're doing.